### PR TITLE
feat: implement comprehensive debug mode for addon cost debugging

### DIFF
--- a/DEBUG_MODE_README.md
+++ b/DEBUG_MODE_README.md
@@ -1,0 +1,187 @@
+# Eveve React Widget – Debug Mode Reference Guide
+
+_Updated August 2025_
+
+---
+
+## 1. What Is Debug Mode?  
+
+Debug mode is a **developer-only overlay** that surfaces the internal state of the Eveve booking widget directly in the UI—no need to inspect Redux, React DevTools or console logs.  
+When enabled it renders colour-coded panels at critical stages of the flow, showing **variable names and live values** so you can quickly trace data as it moves from page ➊ (search & addons) to page ➋ (details / payment).
+
+| Panel Colour | Location | Primary Purpose |
+|--------------|-----------|-----------------|
+| 🟡 Yellow    | Selected Add-ons Summary (Booking page) | Costs, addon UIDs/qty/pricing |
+| 🟠 Orange    | “Proceed to Booking” button (Booking page) | Time / date / covers / area that will be posted to hold endpoint |
+| 🔵 Blue      | Booking Summary (Details modal) | Final payload preview incl. transferred addon cost |
+
+---
+
+## 2. Enabling / Disabling
+
+Debug mode is toggled by a single **URL parameter**:
+
+```
+?debug=true      # enable
+?debug=false     # disable (or remove the param)
+```
+
+The flag is read once on page load by `ReservationForm.jsx`:
+
+```js
+const debugMode = new URLSearchParams(window.location.search).get('debug') === 'true';
+```
+
+No build-time flags, environment variables or re-compile are required—works the same in `npm run dev` and production builds.
+
+---
+
+## 3. Panels in Detail
+
+### 3.1 Selected Add-ons Summary Panel 🟡
+
+Location: Under the “Selected Add-ons Summary” card on the booking page.
+
+Shows:
+
+* `totalAddonCost` – _raw cents_
+* `totalAddonCost (formatted)` – currency string (`$12.50`)
+* Counts:
+  * `selectedAddons.menus.length`
+  * `Object.keys(selectedAddons.options).length`
+* `guestCount`
+* **Detailed Menus**  
+  ```
+  menu[0].uid          // numeric UID
+  menu[0].name         // display name
+  menu[0].price        // price in cents
+  menu[0].quantity     // qty (usage:2)
+  menu[0].per          // "Guest", "Item", "Party" …
+  ```
+* **Detailed Options**  
+  ```
+  option[0].uid
+  option[0].quantity
+  option[0].name
+  option[0].price
+  option[0].per
+  ```
+
+### 3.2 Booking Button Panel 🟠
+
+Location: Immediately below the purple “Proceed to Booking” button.
+
+Shows:
+
+```
+selectedShiftTime.name
+selectedDate                     // YYYY-MM-DD
+guests
+selectedShiftTime.selectedTime   // decimal time e.g. 18.75
+selectedAreaName
+selectedArea                     // UID | "any" | null
+proceedButtonState.text
+proceedButtonState.disabled      // true | false
+```
+
+### 3.3 Booking Summary Panel 🔵
+
+Location: Inside `BookingDetailsModal` under the standard “Booking Summary”.
+
+Shows:
+
+```
+bookingData.formattedDate
+bookingData.time
+bookingData.covers
+bookingData.areaName
+bookingData.formattedAddons      // human-readable string
+bookingData.addons               // uid[:qty],uid…
+totalAddonCost                   // carried forward (cents)
+totalAddonCost (formatted)
+bookingData.area
+holdData.perHead
+holdData.uid
+holdData.card                    // 0 none, 1 no-show, 2 deposit
+```
+
+---
+
+## 4. Implementation Notes (Developer)
+
+1. **ReservationForm.jsx**
+   * Detects `debug` URL param.
+   * Passes `debugMode` to `SelectedAddonsSummary` and `BookingDetailsModal`.
+   * Calculates `totalAddonCost` **once** when user clicks “Proceed to Booking” and injects it into `bookingData`.
+
+2. **SelectedAddonsSummary.jsx**
+   * New `debugMode` prop renders yellow panel.
+   * Utility `findAddonByUid` enables name/price lookup for options.
+   * Loops through `selectedAddons` to output raw values.
+
+3. **Booking Button Section (inside ReservationForm)**
+   * Inline JSX block renders orange panel when `debugMode`.
+
+4. **BookingDetailsModal.jsx**
+   * Accepts `debugMode` prop.
+   * Blue panel added to `renderBookingSummary()`.
+   * Displays `totalAddonCost` passed via `bookingData`.
+
+5. **Styling**
+   * Tailwind utility classes—no global CSS changes.
+   * Colours chosen for high contrast but easy removal.
+
+---
+
+## 5. Usage Examples
+
+### Local Dev
+
+```
+npm run dev
+open http://localhost:5173/?est=demo123&debug=true
+```
+
+### Production QA
+
+```
+https://your-site.com/booking-widget/?est=55&covers=2&debug=true
+```
+
+Disable quickly by deleting `debug=true` or toggling browser query string editor.
+
+---
+
+## 6. Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| No debug panels visible | Missing or misspelled `debug=true` | Check URL query string |
+| Yellow panel missing prices | `currentShiftAddons` not passed / addon price undefined | Verify API response contains `price` field |
+| Blue panel shows `totalAddonCost: null` | Calculation failed or not passed | Ensure “Proceed to Booking” was clicked **after** addons selected; confirm ReservationForm calculation code present |
+| Panel overlaps content | Temporary dev feature; adjust Tailwind classes or hide debug mode |
+
+---
+
+## 7. Screenshot Placeholders
+
+> Replace with real images or GIFs in `/docs/images/` once available.
+
+| Panel | Example |
+|-------|---------|
+| Selected Add-ons Summary 🟡 | ![Yellow panel](docs/images/debug-yellow.png) |
+| Booking Button 🟠 | ![Orange panel](docs/images/debug-orange.png) |
+| Booking Summary 🔵 | ![Blue panel](docs/images/debug-blue.png) |
+
+---
+
+## 8. Extending Debug Mode
+
+* **Add new variables**: locate the relevant panel’s JSX block and insert additional `<div className="flex justify-between">` rows.
+* **Different trigger**: change the URL param test in `ReservationForm`—e.g., read from `localStorage` or environment variable.
+* **Production safety**: since debug panels are pure client-side, they will never render unless the flag is explicitly present.
+
+---
+
+### Happy Debugging!  
+For questions contact the frontend team / #eveve-widget-dev Slack channel.

--- a/src/components/SelectedAddonsSummary.jsx
+++ b/src/components/SelectedAddonsSummary.jsx
@@ -1,6 +1,13 @@
 import React from 'react';
 
-const SelectedAddonsSummary = ({ selectedAddons, currencySymbol, languageStrings, guestCount, currentShiftAddons }) => {
+const SelectedAddonsSummary = ({
+  selectedAddons,
+  currencySymbol,
+  languageStrings,
+  guestCount,
+  currentShiftAddons,
+  debugMode = false,      // default false
+}) => {
   const numericGuestCount = parseInt(guestCount, 10) || 1; // Default to 1 if guestCount is not valid, for per-guest calculation
   const displaySymbol = currencySymbol || '$';
 
@@ -180,6 +187,149 @@ const SelectedAddonsSummary = ({ selectedAddons, currencySymbol, languageStrings
         <p className="text-sm text-gray-500 italic">
           {languageStrings?.noAddonsSelected || 'No addons selected.'}
         </p>
+      )}
+
+      {/* Debug Mode Information */}
+      {debugMode && (
+        <div className="mt-4 p-3 border-2 border-yellow-400 rounded-lg bg-yellow-50">
+          <h6 className="text-sm font-bold text-yellow-800 mb-2">
+            🐛 Debug Information (Dev Mode)
+          </h6>
+          <div className="text-xs text-yellow-700 space-y-1">
+            <div className="flex justify-between">
+              <span className="font-mono">totalAddonCost:</span>
+              <span className="font-mono">{totalAddonCost}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="font-mono">totalAddonCost&nbsp;(formatted):</span>
+              <span className="font-mono">
+                {displaySymbol}
+                {(totalAddonCost / 100).toFixed(2)}
+              </span>
+            </div>
+            <div className="flex justify-between">
+              <span className="font-mono">
+                selectedAddons.menus.length:
+              </span>
+              <span className="font-mono">
+                {selectedAddons.menus.length}
+              </span>
+            </div>
+            <div className="flex justify-between">
+              <span className="font-mono">
+                Object.keys(selectedAddons.options).length:
+              </span>
+              <span className="font-mono">
+                {Object.keys(selectedAddons.options).length}
+              </span>
+            </div>
+            <div className="flex justify-between">
+              <span className="font-mono">guestCount:</span>
+              <span className="font-mono">{guestCount}</span>
+            </div>
+
+            {/* ------------------------------------------------------------------
+                 Detailed list of selected menus
+            ------------------------------------------------------------------ */}
+            <div className="mt-3 pt-2 border-t border-yellow-300">
+              <div className="text-sm font-bold text-yellow-800 mb-1">
+                Selected Menus:
+              </div>
+              {selectedAddons.menus.length > 0 ? (
+                selectedAddons.menus.map((menu, idx) => (
+                  <div key={idx} className="ml-2 mb-1 text-xs">
+                    <div className="flex justify-between">
+                      <span className="font-mono">menu[{idx}].uid:</span>
+                      <span className="font-mono">{menu.uid}</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="font-mono">menu[{idx}].name:</span>
+                      <span className="font-mono">"{menu.name}"</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="font-mono">menu[{idx}].price:</span>
+                      <span className="font-mono">{typeof menu.price === 'number' ? menu.price : 'null'}</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="font-mono">menu[{idx}].quantity:</span>
+                      <span className="font-mono">{menu.quantity || 1}</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="font-mono">menu[{idx}].per:</span>
+                      <span className="font-mono">{menu.per ? `"${menu.per}"` : 'null'}</span>
+                    </div>
+                    {idx < selectedAddons.menus.length - 1 && (
+                      <div className="border-b border-yellow-200 my-1"></div>
+                    )}
+                  </div>
+                ))
+              ) : (
+                <div className="ml-2 text-xs text-yellow-600">
+                  No menus selected
+                </div>
+              )}
+            </div>
+
+            {/* ------------------------------------------------------------------
+                 Detailed list of selected options
+            ------------------------------------------------------------------ */}
+            <div className="mt-3 pt-2 border-t border-yellow-300">
+              <div className="text-sm font-bold text-yellow-800 mb-1">
+                Selected Options:
+              </div>
+              {Object.keys(selectedAddons.options).length > 0 ? (
+                Object.entries(selectedAddons.options).map(
+                  ([optionUid, quantity], idx) => {
+                    const optionAddon = findAddonByUid(optionUid);
+                    return (
+                      <div key={optionUid} className="ml-2 mb-1 text-xs">
+                        <div className="flex justify-between">
+                          <span className="font-mono">option[{idx}].uid:</span>
+                          <span className="font-mono">{optionUid}</span>
+                        </div>
+                        <div className="flex justify-between">
+                          <span className="font-mono">option[{idx}].quantity:</span>
+                          <span className="font-mono">{quantity}</span>
+                        </div>
+                        {optionAddon && (
+                          <>
+                            <div className="flex justify-between">
+                              <span className="font-mono">option[{idx}].name:</span>
+                              <span className="font-mono">
+                                "{optionAddon.name}"
+                              </span>
+                            </div>
+                            <div className="flex justify-between">
+                              <span className="font-mono">option[{idx}].price:</span>
+                              <span className="font-mono">
+                                {typeof optionAddon.price === 'number'
+                                  ? optionAddon.price
+                                  : 'null'}
+                              </span>
+                            </div>
+                            <div className="flex justify-between">
+                              <span className="font-mono">option[{idx}].per:</span>
+                              <span className="font-mono">
+                                {optionAddon.per ? `"${optionAddon.per}"` : 'null'}
+                              </span>
+                            </div>
+                          </>
+                        )}
+                        {idx < Object.keys(selectedAddons.options).length - 1 && (
+                          <div className="border-b border-yellow-200 my-1"></div>
+                        )}
+                      </div>
+                    );
+                  }
+                )
+              ) : (
+                <div className="ml-2 text-xs text-yellow-600">
+                  No options selected
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/src/components/booking/BookingDetailsModal.jsx
+++ b/src/components/booking/BookingDetailsModal.jsx
@@ -19,6 +19,7 @@ import { formatAddonsForDisplay } from "../../utils/apiFormatter";
  * @param {boolean} props.isLoading - Whether the form is submitting
  * @param {string} props.error - Error message if submission failed
  * @param {boolean} props.success - Whether submission was successful
+ * @param {boolean} [props.debugMode=false] - Enable developer debug panel
  */
 export default function BookingDetailsModal({
   isOpen,
@@ -29,7 +30,8 @@ export default function BookingDetailsModal({
   appConfig,
   isLoading = false,
   error = null,
-  success = false
+  success = false,
+  debugMode = false
 }) {
   // Form step state
   const STEPS = {
@@ -827,6 +829,77 @@ export default function BookingDetailsModal({
         {holdData && holdData.perHead && (
           <div className="mt-2 text-sm font-bold">
             <span>{appConfig?.lng?.bookingTotalPrice || "Total Price"}:</span> ${(holdData.perHead * bookingData.covers / 100).toFixed(2)}
+          </div>
+        )}
+
+        {/* Debug Mode Information for Booking Summary */}
+        {debugMode && (
+          <div className="mt-4 p-3 border-2 border-blue-400 rounded-lg bg-blue-50">
+            <h6 className="text-sm font-bold text-blue-800 mb-2">
+              🐛 Booking Summary Debug (Dev Mode)
+            </h6>
+            <div className="text-xs text-blue-700 space-y-1">
+              <div className="flex justify-between">
+                <span className="font-mono">bookingData.formattedDate:</span>
+                <span className="font-mono">{bookingData?.formattedDate || 'null'}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="font-mono">bookingData.time:</span>
+                <span className="font-mono">{bookingData?.time || 'null'}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="font-mono">bookingData.covers:</span>
+                <span className="font-mono">{bookingData?.covers || 'null'}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="font-mono">bookingData.areaName:</span>
+                <span className="font-mono">{bookingData?.areaName || 'null'}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="font-mono">bookingData.formattedAddons:</span>
+                <span className="font-mono">{bookingData?.formattedAddons || 'null'}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="font-mono">bookingData.addons:</span>
+                <span className="font-mono">{bookingData?.addons || 'null'}</span>
+              </div>
+              {/* -------------------------------------------------------
+                   Total Add-on Cost (raw + formatted) – passed from the
+                   first page in bookingData.totalAddonCost (cents)
+                 ------------------------------------------------------- */}
+              <div className="flex justify-between">
+                <span className="font-mono">totalAddonCost:</span>
+                <span className="font-mono">
+                  {bookingData?.totalAddonCost !== undefined
+                    ? bookingData.totalAddonCost
+                    : 'null'}
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span className="font-mono">totalAddonCost&nbsp;(formatted):</span>
+                <span className="font-mono">
+                  {bookingData?.totalAddonCost !== undefined
+                    ? `$${(bookingData.totalAddonCost / 100).toFixed(2)}`
+                    : 'null'}
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span className="font-mono">bookingData.area:</span>
+                <span className="font-mono">{bookingData?.area || 'null'}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="font-mono">holdData.perHead:</span>
+                <span className="font-mono">{holdData?.perHead || 'null'}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="font-mono">holdData.uid:</span>
+                <span className="font-mono">{holdData?.uid || 'null'}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="font-mono">holdData.card:</span>
+                <span className="font-mono">{holdData?.card || 'null'}</span>
+              </div>
+            </div>
           </div>
         )}
       </div>


### PR DESCRIPTION
- Add URL parameter debug mode toggle (?debug=true)
- Implement three debug panels with color-coded information:
  * Yellow panel: Selected Add-ons Summary with detailed addon UIDs, quantities, and prices
  * Orange panel: Booking Button with date/time/area variables
  * Blue panel: Booking Summary with final booking data and transferred addon costs
- Calculate and transfer totalAddonCost from booking page to details page
- Add comprehensive DEBUG_MODE_README.md documentation
- Enable real-time debugging of addon value transfer issues

Modified files:
- src/components/ReservationForm.jsx: URL param detection, debug props, totalAddonCost calculation
- src/components/SelectedAddonsSummary.jsx: Yellow debug panel with detailed addon breakdown
- src/components/booking/BookingDetailsModal.jsx: Blue debug panel with booking summary variables
- DEBUG_MODE_README.md: Complete debug mode reference guide