### PR TITLE
Display all Event shift times directly from API

### DIFF
--- a/src/components/ReservationForm.jsx
+++ b/src/components/ReservationForm.jsx
@@ -1482,9 +1482,9 @@ export default function ReservationForm() {
                                   // First, filter out negative times (blocked times)
                                   if (timeValue < 0) return false;
                                   
-                                  // If this is an Event shift, filter by available times from non-Event shifts
+                                  // If this is an Event shift, show all times returned by the API
                                   if (shift.type === "Event") {
-                                    return availableTimesForEvents.includes(timeValue);
+                                    return true; // Display all times for Event shifts
                                   }
                                   
                                   // For non-Event shifts, just return true (keep all positive times)


### PR DESCRIPTION
- Change Event shift filtering logic to show all times returned by API
- Previously Event shifts were filtered against regular shift times
- Now Event shifts display all times in their times array as per new API behavior
- This aligns with updated day-avail API where Event times are directly available